### PR TITLE
Fix build error undefined reference to `shm_open'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -144,7 +144,7 @@ examples: $(EXAMPLES)
 hiredis-test: test.o $(STLIBNAME)
 
 hiredis-%: %.o $(STLIBNAME)
-	$(CC) $(REAL_CFLAGS) -o $@ $(REAL_LDFLAGS) $< $(STLIBNAME)
+	$(CC) $(REAL_CFLAGS) -o $@ $< $(STLIBNAME) $(REAL_LDFLAGS)
 
 test: hiredis-test
 	./hiredis-test


### PR DESCRIPTION
https://gcc.gnu.org/onlinedocs/gcc/Link-Options.html
Move -lrt to end